### PR TITLE
Noticed the preprocessor doesn't handle an obscure case

### DIFF
--- a/src/hcc.c
+++ b/src/hcc.c
@@ -2457,7 +2457,7 @@ void hcc_pp_copy_expand_range(HccCompiler* c, HccPPExpand* expand, HccTokenBag* 
 		//
 		*hcc_stack_push(dst_bag->tokens) = token;
 
-		U32 mask = (flags & HCC_PP_EXPAND_FLAGS_IS_ARGS | HCC_PP_EXPAND_FLAGS_DEST_IS_ARGS) ? HCC_PP_TOKEN_IS_PREEXPANDED_MACRO_ARG_MASK : 0;
+		U32 mask = (flags & (HCC_PP_EXPAND_FLAGS_IS_ARGS | HCC_PP_EXPAND_FLAGS_DEST_IS_ARGS)) ? HCC_PP_TOKEN_IS_PREEXPANDED_MACRO_ARG_MASK : 0;
 		*hcc_stack_push(dst_bag->token_location_indices) = location_idx | mask;
 
 		expand->cursor.token_idx += 1;

--- a/src/hcc_main.c
+++ b/src/hcc_main.c
@@ -8,7 +8,7 @@ int main(int argc, char** argv) {
 	HccCompiler compiler = {0};
 	hcc_compiler_init(&compiler, &compiler_setup);
 
-	if (!hcc_compiler_compile(&compiler, "tests/test.c")) {
+	if (!hcc_compiler_compile(&compiler, "tests/demonstrate_really_dumb_very_annoying_no_good_preprocessor_feature.c")) {
 		if (compiler.allocation_failure_alloc_tag != HCC_ALLOC_TAG_NONE) {
 			printf("failed to allocate '%s'\n", hcc_alloc_tag_strings[compiler.allocation_failure_alloc_tag]);
 		}

--- a/tests/demonstrate_really_dumb_very_annoying_no_good_preprocessor_feature.c
+++ b/tests/demonstrate_really_dumb_very_annoying_no_good_preprocessor_feature.c
@@ -1,0 +1,33 @@
+
+// I ran into this when parsing the handmade hero codebase which I would have
+// been happy if I'd gone my whole life not knowing about
+#if 1
+int function_taking_three_arguments(int a, int b, int c)
+{
+  return 0;
+}
+
+#define dumb_preprocessor_feature(a, b, ...) \
+  function_taking_three_arguments(a, b, ## __VA_ARGS__)
+
+int main()
+{
+  dumb_preprocessor_feature(1, 2, 3);
+}
+
+#endif
+
+
+// Just happened to notice the parser doesn't handle this.  Not sure if this is 
+#if 0
+void func_with_no_return_value()
+{
+  return;
+}
+#endif
+
+// Not sure if the preprocessor is meant to handle this case yet, but it doesn't
+#define bug3 0
+#if bug3
+this doesnt error, oh noes!
+#endif


### PR DESCRIPTION
Saw you programming on Twitch the other day.  I'm also writing a C compiler and I decided to take a closer look at `hcc`.

I had to fix a typo to get it to compile.  I'm assuming I did the right thing .. but .. it is in the preprocessor code.  Anyhow..

During my reading I noticed the `hcc` preprocessor doesn't handle a weird case that's pretty rare (AFAIK) in the wild, but I did run into it parsing the handmade hero codebase.

Here's a link to some documentation about it: https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html

Both clang and gcc accept the demo code I wrote, fwiw.

Looking forward to using `hcc` in the future!!