### PR TITLE
Find the exe path directly instead of using argv[0]

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -459,6 +459,24 @@ bool hcc_make_directory(const char* path) {
 	return true;
 }
 
+HccString hcc_path_to_exe(void) {
+	char buf[PATH_MAX];
+#ifdef HCC_OS_LINUX
+	int64_t buf_size = readlink("/proc/self/exe", buf, PATH_MAX);
+#elif defined(HCC_OS_WINDOWS)
+	int64_t buf_size = GetModuleFileName(NULL, buf, PATH_MAX);
+	if (buf_size <= 0) {
+		return hcc_string_lit("");
+	}
+#else
+	#error "unimplemented for this platform"
+#endif
+	char* new_buf = HCC_ARENA_ALCTOR_ALLOC_ARRAY_THREAD_SAFE(char, &_hcc_gs.arena_alctor, buf_size + 1);
+	memcpy(new_buf, buf, buf_size);
+	new_buf[buf_size] = '\0';
+	return hcc_string(new_buf, buf_size);
+}
+
 HccString hcc_path_replace_file_name(HccString parent, HccString file_name) {
 	uint32_t parent_copy_size = parent.size;
 	while (parent_copy_size) {

--- a/src/hcc_internal.h
+++ b/src/hcc_internal.h
@@ -213,6 +213,7 @@ bool hcc_path_exists(const char* path);
 bool hcc_path_is_file(const char* path);
 bool hcc_path_is_directory(const char* path);
 bool hcc_make_directory(const char* path);
+HccString hcc_path_to_exe(void);
 HccString hcc_path_replace_file_name(HccString parent, HccString file_name);
 uint32_t hcc_logical_cores_count(void);
 int hcc_execute_shell_command(const char* shell_command);

--- a/src/hcc_main.c
+++ b/src/hcc_main.c
@@ -295,21 +295,22 @@ int main(int argc, char** argv) {
 		arg_idx += 1;
 	}
 
+	HccString exe_path = hcc_path_to_exe();
 	{
-		HccString path = hcc_path_replace_file_name(hcc_string_c(argv[0]), hcc_string_lit("libc"));
+		HccString path = hcc_path_replace_file_name(exe_path, hcc_string_lit("libc"));
 		HCC_ENSURE(hcc_task_add_include_path(task, path));
 	}
 
 	{
-		HccString path = hcc_path_replace_file_name(hcc_string_c(argv[0]), hcc_string_lit("libhccintrinsics"));
+		HccString path = hcc_path_replace_file_name(exe_path, hcc_string_lit("libhccintrinsics"));
 		HCC_ENSURE(hcc_task_add_include_path(task, path));
 	}
 
 	{
-		HccString path = hcc_path_replace_file_name(hcc_string_c(argv[0]), hcc_string_lit("libhmaths"));
+		HccString path = hcc_path_replace_file_name(exe_path, hcc_string_lit("libhmaths"));
 		HCC_ENSURE(hcc_task_add_include_path(task, path));
 
-		path = hcc_path_replace_file_name(hcc_string_c(argv[0]), hcc_string_lit("libhmaths/hmaths.c"));
+		path = hcc_path_replace_file_name(exe_path, hcc_string_lit("libhmaths/hmaths.c"));
 		HCC_ENSURE(hcc_task_add_input_code_file(task, path.data, NULL));
 	}
 


### PR DESCRIPTION
When running hcc from the path on windows, the associated argv[0] is not an absolute path to the executable. This is problematic when it tries to load libc/libhccintrinsics/etc..

This patch includes a way to fetch the absolute path to the hcc executable and uses that to resolve sibling include directories

examples of the failure on windows:

![find-exe-fail](https://github.com/user-attachments/assets/07b9d4c9-1b4e-4750-8c14-5b9ed9797bdb)
![find-exe-fail-w64-devkit](https://github.com/user-attachments/assets/ba4c9348-d0aa-472c-b03f-9136e1e0993f)

I also tested this on wsl (ubuntu)

__before__
![find-exe-fail-wsl](https://github.com/user-attachments/assets/a6478706-ed83-4f1b-af3d-0e5fa3821ce4)

__after__
![find-exe-success-wsl](https://github.com/user-attachments/assets/385b53f1-c7c7-45e4-8984-a67e19cead40)
